### PR TITLE
Ensure that tracing spans cannot have a negative duration

### DIFF
--- a/src/Jaeger/Span.php
+++ b/src/Jaeger/Span.php
@@ -83,6 +83,10 @@ final class Span implements OTSpan
     {
         // mark the duration
         $this->duration = microtime(true) - $this->startTime;
+        if ($this->duration < 0) {
+            // Negative duration is not possible, and causes overflow making the span look like it lasted 584,512 years.
+            $this->duration = 0;
+        }
 
         // report ourselves to the Tracer
         $this->tracer->reportSpan($this);


### PR DESCRIPTION
Ensure that tracing spans cannot have a negative duration, because they can overflow and read as 584,512 years :facepalm: