### PR TITLE
Update overlooked method name change: Reference::getContext -> Reference::getSpanContext

### DIFF
--- a/src/Jaeger/Span.php
+++ b/src/Jaeger/Span.php
@@ -49,8 +49,8 @@ final class Span implements OTSpan
                 if ($parentId != null) {
                     throw new \Exception("can't be a child of two things");
                 }
-                $traceId = $ref->getContext()->getTraceID();
-                $parentId = $ref->getContext()->getSpanID();
+                $traceId = $ref->getSpanContext()->getTraceID();
+                $parentId = $ref->getSpanContext()->getSpanID();
             }
         }
         $this->context = SpanContext::create($traceId, $parentId);

--- a/src/Jaeger/Transport/JaegerTransport.php
+++ b/src/Jaeger/Transport/JaegerTransport.php
@@ -124,13 +124,13 @@ final class JaegerTransport implements Transport
                 $type = SpanRefType::FOLLOWS_FROM;
             }
 
-            $traceId = $reference->getContext()->getTraceID();
+            $traceId = $reference->getSpanContext()->getTraceID();
 
             return new SpanRef([
                 "refType" => $type,
                 "traceIdLow" => (is_array($traceId) ? $traceId["low"] : $traceId),
                 "traceIdHigh" => (is_array($traceId) ? $traceId["high"] : 0),
-                "spanId" => $reference->getContext()->getSpanID(),
+                "spanId" => $reference->getSpanContext()->getSpanID(),
             ]);
         }, $span->getReferences());
 


### PR DESCRIPTION
Rather self-explanatory. This was missed in the 0.4.0 change for `opentracing-php@v1.0.1` compatibility.